### PR TITLE
Add link to where the guide is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 This repository has been established to host an editable version of the UNGGIM Standards Guide titled: _A Guide to the Role of Standards in Geospatial Information Management_.  This version is based upon Edition 3 Draft, in which Review/comments were invited by 31 October 2021.  Although that deadline has passed, comments can still be submitted to: UNStdsGuideComments@lists.ogc.org
+The published guide is at http://standards.unggim.ogc.org/index.php


### PR DESCRIPTION
In case people stumble across this but are actually looking for the published guide.
"Web of discoverability"